### PR TITLE
the package in npm is called dss, not DSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ This plugin requires Grunt `~0.4.0`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install DSS --save-dev
+npm install dss --save-dev
 ```
 
 One the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('DSS');
+grunt.loadNpmTasks('dss');
 ```
 
 ## The "DSS" task


### PR DESCRIPTION
so 'npm install DSS' does not work, but 'npm install dss' does.
