### PR TITLE
Add multiline support for variables, fix @markup implementation & update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,21 @@
 
 [![NPM](https://nodei.co/npm/dss.png?downloadRank=true)](https://npmjs.org/package/dss)  
 
-**DSS**, Documented Style Sheets, is a comment guide and parser for CSS, LESS, STYLUS, SASS and SCSS code. This project does static file analysis and parsing to generate a documentation object to be used for generating styleguides.
+**DSS**, Documented Style Sheets is a comment guide and parser for CSS, LESS, STYLUS, SASS and SCSS code. This project does static file analysis and parsing to generate an object to be used for generating styleguides.
 
 
 ##### Table of Contents
 
-- [Other Projects](#other-projects)
 - [Parsing a File](#parsing-a-file)
-  - [**Examples**](#examples)
-  - [`dss.detector`](#dss-detector)
-  - [`dss.parser`](#dss-parser)
-
-### Other Projects
-- [Grunt Plugin](http://github.com/dsswg/grunt-dss)
-- [Gulp Plugin](http://github.com/dsswg/gulp-dss)
-- [Sublime Text Plugin](https://github.com/sc8696/sublime-css-auto-comments)
-- [UX Recorder](http://github.com/dsswg/dss-recorder)
-- [UX Player](http://github.com/dsswg/dss-player)
+  - [`dss.detector`](#dssdetector-callback-)
+  - [`dss.parser`](#dssparser-name-callback-)
+- [Other Projects](#other-projects)
 
 ### Parsing a File
 
 In most cases, you will want to include the **DSS** parser in a build step that will generate documentation files automatically (or you just want to play around with this returned `Object` for other means); Either way, we officially support a [Grunt Plugin](https://github.com/dsswg/grunt-dss) and a [Gulp Plugin](http://github.com/dsswg/gulp-dss).
 
-#### Examples
+### Examples
 
 ##### Example Comment Block Format
 
@@ -163,3 +155,10 @@ dss.parser( 'link', function () {
    
 });
 ````
+
+### Other Projects
+- [Grunt Plugin](http://github.com/dsswg/grunt-dss)
+- [Gulp Plugin](http://github.com/dsswg/gulp-dss)
+- [Sublime Text Plugin](https://github.com/sc8696/sublime-css-auto-comments)
+- [UX Recorder](http://github.com/dsswg/dss-recorder)
+- [UX Player](http://github.com/dsswg/dss-player)

--- a/dss.js
+++ b/dss.js
@@ -475,24 +475,6 @@ dss.parser( 'state', function () {
 
 // Describe default parsing of a piece markup
 dss.parser( 'markup', function () {
-
-  // Get the first line of code (which should be the type of markup it's written in)
-  this.line.contents = this.line.contents.split('\n');
-  var type = this.line.contents[ 0 ].toLowerCase();
-
-  // Remove first line from contents
-  this.line.contents = this.line.contents.splice( 1, this.line.contents.length ).join( '\n' );
-
-  // Render contents with HTML or another parser if passed through options
-  console.log( 'type', type );
-  if ( type && type != 'html' ) {
-    if ( this.options[ this.name ] && typeof this.options[ this.name ][ type ] == 'function' ) {
-      this.options[ this.name ][ type ]( this.line.contents );
-    } else {
-      console.warn( '@' + this.name + ' parser error. Falling back.');
-    }
-  }
-
   return [{
     example: this.line.contents,
     escaped: this.line.contents.replace( /</g, '&lt;' ).replace( />/g, '&gt;' )

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "scripts": {
+  "scripts": {},
+  "dependencies": {
+    "jade": "^1.9.2",
+    "marked": "^0.3.3"
   },
-  "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {},
   "keywords": [


### PR DESCRIPTION
Slowly getting this project up to snuff. Updated the parsing implementation so that it now supports multiline variables (#56). This also fixes multiple `@markup`  variables (#54). Along with this change, I've gone ahead and refactored how we provide information/variables to the callback functions passed to `dss.parser()`. We give you interesting information like `this.line.from` and `this.line.to` which are line numbers associated with the contents of a variable (#53).

Documentation had not been touched in a long time, so I've now update it and will cut a new release once I'm happy that all of these changes aren't breaking anything they shouldn't be. The API has changed slightly (as noted above) so I'm a bit torn as to whether I should make this a major release or not (thoughts/opinions welcome).

I may write a custom parser to show how you can  address #51, providing support for  **Jade**, **Markdown**, **HAML** or whatever language for your @markup example.
