### PR TITLE
Add simple (failing) unit test (run via `npm run test`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,16 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "nodeunit"
+  },
   "dependencies": {
     "jade": "^1.9.2",
     "marked": "^0.3.3"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "nodeunit": "^0.9.1"
+  },
   "peerDependencies": {},
   "keywords": [
     "css",

--- a/test/data/button.css
+++ b/test/data/button.css
@@ -1,0 +1,12 @@
+//
+// @name Button
+// @description Your standard form button.
+//
+// @state :hover - Highlights when hovering.
+// @state :disabled - Dims the button when disabled.
+// @state .primary - Indicates button is the primary action.
+// @state .smaller - A smaller button
+//
+// @markup
+//   <button>This is a button</button>
+//

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -1,0 +1,15 @@
+var dss = require('../dss');
+var fs = require('fs');
+var path = require('path');
+
+exports.testParse = function(test){
+  test.expect(2);
+
+  var fileContents = fs.readFileSync(path.join(__dirname, 'data/button.css'), 'utf8');
+  dss.parse(fileContents, {}, function(parsed) {
+    var block = parsed.blocks[0];
+    test.equal(block.name, 'Button');
+    test.equal(block.description, 'Your standard form button.');
+    test.done();
+  });
+};


### PR DESCRIPTION
Added a simple unit test to ease further development. You can run the test via `npm run test`. 

The tests are failing in master, but merging it now should help fixing the problem. Here's the current output:
````
AssertionError: '>' == 'Button'

AssertionError: 'Your standard form button.\n @state :hover - Highlights when hovering.\n @state :disabled - Dims the button when disabled.\n @state .primary - Indicates button is the primary action.\n @state .smaller - A smaller button\n @markup\n   <button>This is a button</button>' == 'Your standard form button.'
```