### PR TITLE
Fix parse for multiline comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store?
 /examples/
 test.js
+npm-debug.log

--- a/dss.js
+++ b/dss.js
@@ -319,7 +319,7 @@ var dss = ( function () {
     // in order to isolate the current multi-line parser
     var nextParserIndex = block.indexOf( '* @', output.line.from + 1 );
     var markupLength = ( nextParserIndex > -1 ) ? nextParserIndex - output.line.from : block.length;
-    var contents = block.split( '' ).splice( ( output.line.from - 1 ), markupLength ).join( '' );
+    var contents = block.split( '' ).splice( output.line.from , markupLength ).join( '' );
     var parserMarker = '@' + name;
     contents = contents.replace( parserMarker, '' );
 
@@ -333,7 +333,7 @@ var dss = ( function () {
         var pattern = '*';
         var index = line.indexOf( pattern );
 
-        if ( index > 0 && index < 10 ) {
+        if ( index >= 0 && index < 10 ) {
           line = line.split( '' ).splice( ( index + pattern.length ), line.length ).join( '' );
         }
 

--- a/test/data/button.css
+++ b/test/data/button.css
@@ -1,12 +1,10 @@
-//
-// @name Button
-// @description Your standard form button.
-//
-// @state :hover - Highlights when hovering.
-// @state :disabled - Dims the button when disabled.
-// @state .primary - Indicates button is the primary action.
-// @state .smaller - A smaller button
-//
-// @markup
-//   <button>This is a button</button>
-//
+/*
+* @name Button
+* @description Your standard form button.
+*
+* @state :hover - Highlights when hovering.
+* @state .smaller - A smaller button
+*
+* @markup
+*   <button>This is a button</button>
+*/

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -3,13 +3,24 @@ var fs = require('fs');
 var path = require('path');
 
 exports.testParse = function(test){
-  test.expect(2);
+  test.expect(10);
 
   var fileContents = fs.readFileSync(path.join(__dirname, 'data/button.css'), 'utf8');
   dss.parse(fileContents, {}, function(parsed) {
     var block = parsed.blocks[0];
     test.equal(block.name, 'Button');
     test.equal(block.description, 'Your standard form button.');
+
+    test.equal(block.state.length, 2);
+    test.equal(block.state[0].name, ':hover');
+    test.equal(block.state[0].description, 'Highlights when hovering.');
+
+    test.equal(block.state[1].name, '.smaller');
+    test.equal(block.state[1].description, 'A smaller button');
+
+    test.equal(block.markup.length, 1);
+    test.equal(block.markup[0].example.trim(), '<button>This is a button</button>');
+    test.equal(block.markup[0].escaped.trim(), '&lt;button&gt;This is a button&lt;/button&gt;');
     test.done();
   });
 };


### PR DESCRIPTION
The current implementation seems to work only for multiline commments with leading "*". This  PR changes the test data to reflect this and fixed a bug (#67) that remained after changing the test-data.

I added a sponsor message in each commit message. I can remove this if you don't like that approach.