### PR TITLE
Changed whitespace trimming and markup rendering behavior to match 1.0.4 and made multiline whitespace handling consistent

### DIFF
--- a/dss.js
+++ b/dss.js
@@ -350,7 +350,6 @@ var dss = (function () {
       });
 
       // Check for a single line and trim whitespace
-      console.log( lines );
       if ( lines.length === 1 ) {
         lines[ 0 ] = _dss.trim( lines[ 0 ] );
       }

--- a/dss.js
+++ b/dss.js
@@ -322,6 +322,7 @@ var dss = (function () {
     var contents = block.split( '' ).splice( output.line.from , markupLength ).join( '' );
     var parserMarker = '@' + name;
     contents = contents.replace( parserMarker, '' );
+    contents = _dss.trim(contents);
 
     // Redefine output contents to support multiline contents
     output.line.contents = ( function( contents ) {

--- a/dss.js
+++ b/dss.js
@@ -328,6 +328,7 @@ var dss = (function () {
     output.line.contents = ( function( contents ) {
       var ret = [];
       var lines = contents.split( '\n' );
+      var leadingWhiteSpace = ""; 
 
       lines.forEach( function( line, i ) {
 
@@ -338,9 +339,13 @@ var dss = (function () {
           line = line.split( '' ).splice( ( index + pattern.length ), line.length ).join( '' );
         }
 
-        // Trim whitespace from the the first line in multiline contents
         if ( i === 0 ) {
+          // Trim whitespace from the the first line in multiline contents
+          leadingWhiteSpace = line.split(/[^ \t\r\n]/)[0].length;
           line = _dss.trim( line );
+        } else {
+          // Trim whitespace from proceeding lines to match the depth of the first line.
+          line = line.slice(leadingWhiteSpace);
         }
 
         if ( line && line.indexOf( parserMarker ) == -1 ) {

--- a/dss.js
+++ b/dss.js
@@ -482,10 +482,10 @@ dss.parser( 'state', function () {
 
 // Describe default parsing of a piece markup
 dss.parser( 'markup', function () {
-  return [{
+  return {
     example: this.line.contents,
     escaped: this.line.contents.replace( /</g, '&lt;' ).replace( />/g, '&gt;' )
-  }];
+  };
 });
 
 // Module exports

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dss",
   "description": "Documented Style Sheets",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/darcyclarke/dss",
   "author": {
     "name": "darcyclarke",

--- a/test/data/multiline.css
+++ b/test/data/multiline.css
@@ -3,4 +3,8 @@
   * @description
   *   Your standard form button.
   *   It works great.
+  * @markup
+  *   <div class="test">
+  *     <a>Test</a>
+  *   </div>
   */

--- a/test/test-multiline.js
+++ b/test/test-multiline.js
@@ -1,0 +1,18 @@
+var dss = require('../dss');
+var fs = require('fs');
+var path = require('path');
+
+exports.testParse = function(test){
+  test.expect(4);
+
+  var fileContents = fs.readFileSync(path.join(__dirname, 'data/multiline.css'), 'utf8');
+  dss.parse(fileContents, {}, function(parsed) {
+    var block = parsed.blocks[0];
+    test.equal(block.name, 'Button');
+    test.equal(block.description, 'Your standard form button.\nIt works great.');
+
+    test.equal(block.markup.example.trim(), '<div class="test">\n  <a>Test</a>\n</div>');
+    test.equal(block.markup.escaped.trim(), '&lt;div class="test"&gt;\n  &lt;a&gt;Test&lt;/a&gt;\n&lt;/div&gt;');
+    test.done();
+  });
+};

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 
 exports.testParse = function(test){
-  test.expect(10);
+  test.expect(9);
 
   var fileContents = fs.readFileSync(path.join(__dirname, 'data/button.css'), 'utf8');
   dss.parse(fileContents, {}, function(parsed) {
@@ -18,9 +18,8 @@ exports.testParse = function(test){
     test.equal(block.state[1].name, '.smaller');
     test.equal(block.state[1].description, 'A smaller button');
 
-    test.equal(block.markup.length, 1);
-    test.equal(block.markup[0].example.trim(), '<button>This is a button</button>');
-    test.equal(block.markup[0].escaped.trim(), '&lt;button&gt;This is a button&lt;/button&gt;');
+    test.equal(block.markup.example.trim(), '<button>This is a button</button>');
+    test.equal(block.markup.escaped.trim(), '&lt;button&gt;This is a button&lt;/button&gt;');
     test.done();
   });
 };


### PR DESCRIPTION
After a bit of debugging, the failing tests seemed to stem from excess whitespace resulting in multiple lines when it should have been a single line.

When I tested with [sourcejs/sourcejs-contrib-dss](https://github.com/sourcejs/sourcejs-contrib-dss), I found that the `@markup` renderer returns an array where it returned a bare object in 1.0.4. While I see there are changes coming to `markup` in #65, returning the bare object keeps backward compatibility.

Lastly, I selfishly introduced a change (with a test!) to how multiline comments are trimmed. When parsing multiple lines, only the whitespace removed from the first line is removed from all proceeding lines, that way indentation is preserved. This is particularly useful in `@markup` examples.

Given the following markup:

``` css
/**
  * @markup
  *   <div class="test">
  *     <a>Test</a>
  *   </div>
  */
```

1.0.4 would return a `markup` value of:

``` html
<div class="test">
    <a>Test</a>
  </div>
```

With the included changes, it will now return:

``` html
<div class="test">
  <a>Test</a>
</div>
```
